### PR TITLE
system(pause) yerine getchar()

### DIFF
--- a/imageprocessing/image processing.cpp
+++ b/imageprocessing/image processing.cpp
@@ -41,7 +41,7 @@ int main() {
 	//Kayma miktari ve cekirdek Boyutunda taþma olup olmadýðýný kontrol ediyor.
 	//Kontrol fonksiyonu false donerse iþleme devam edilemez.
 	if (!Kontrol(cekirdek_boyut, kayma_miktari, tut)) {
-		system("pause");
+		getchar();
 		return -1;
 	}
 	else { // true ise dogrudan devam eder.
@@ -131,7 +131,7 @@ int main() {
 	}
 
 
-	system("pause");
+	getchar();
 	return 0;
 }
 


### PR DESCRIPTION
system(pause) yöntemi Linux cihazlarda çalışmıyor.
getchar() fonksiyonu her sistemde çalışıyor ve aynı işlevi görüyor.